### PR TITLE
fix: remove include node types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,8 +9,6 @@
 
 // Imported from: https://github.com/soywiz/typescript-node-definitions/consolidate.d.ts
 
-/// <reference types="node" />
-
 declare var cons: Consolidate;
 
 export = cons;


### PR DESCRIPTION
Since we've removed Bluebird in dts

```ts
import Promise = require("bluebird");
```

So `@types/node` is no longer needed.